### PR TITLE
Use GOPROXY with proxy.golang.org

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,8 +11,9 @@ steps:
   pull: always
   image: golang:1.12
   commands:
-  - go build
-  - go test
+  - go build -v
+  - go test -v
   environment:
     CGO_ENABLED: 0
     GO111MODULE: on
+    GOPROXY: https://proxy.golang.org


### PR DESCRIPTION
Use proxy.golang.org. I have seen that it takes 90s to get all dependencies. This reduces our time to 10s.

/cc @brancz @squat 