### PR TITLE
.drone: make binary statically linked

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -11,11 +11,20 @@ steps:
   pull: always
   image: golang:1.12
   commands:
-  - go build -v
   - go test -v -race ./...
   environment:
     # -race requires cgo
     CGO_ENABLED: 1
+    GO111MODULE: on
+    GOPROXY: https://proxy.golang.org
+
+- name: build
+  pull: always
+  image: golang:1.12
+  commands:
+  - go build -v
+  environment:
+    CGO_ENABLED: 0
     GO111MODULE: on
     GOPROXY: https://proxy.golang.org
 


### PR DESCRIPTION
Right now the binary is dynamically linked due to CGO_ENABLED=1. This
causes the following error when executing inside the alpine container:
```
/usr/bin/thanos-receive-controller: not found
```
This fixes that error by splitting the test phase into an explicit
testing and building phase.

cc @metalmatze 