### PR TITLE
.drone.yml: ensure container is tagged with hash

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -28,6 +28,16 @@ steps:
     GO111MODULE: on
     GOPROXY: https://proxy.golang.org
 
+- name: tags
+  image: golang:1.12
+  commands:
+  - echo -n "$(git rev-parse --abbrev-ref HEAD | tr / -)-$(date +%Y-%m-%d)-$(git rev-parse --short HEAD),latest" > .tags
+  when:
+    branch:
+    - master
+    event:
+    - push
+
 - name: docker
   image: plugins/docker
   settings:

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /thanos-receive-controller
+/.tags


### PR DESCRIPTION
This commit ensures that any time a commit is pushed to master, the
resulting container image will be tagged both with latest as well as a
tag containing the branch, date, and hash as is the case in Thanos e.g.

master-2019-07-16-d924771

cc @metalmatze @kakkoyun 