### PR TITLE
Add Hash-ring metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -492,7 +492,7 @@ func (c *controller) populate(hashrings []receive.HashringConfig, statefulsets m
 			}
 			hashrings[i].Endpoints = endpoints
 			c.hashringNodes.WithLabelValues(h.Hashring).Set(float64(len(endpoints)))
-			c.hashringNodes.WithLabelValues(h.Hashring).Set(float64(len(h.Tenants)))
+			c.hashringTenants.WithLabelValues(h.Hashring).Set(float64(len(h.Tenants)))
 		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -351,14 +351,14 @@ func newController(klient kubernetes.Interface, logger log.Logger, o *options) *
 		),
 		hashringNodes: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "thanos_receive_controller_hashrings_nodes",
+				Name: "thanos_receive_controller_hashring_nodes",
 				Help: "The number of nodes per hashring.",
 			},
 			[]string{"name"},
 		),
 		hashringTenants: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
-				Name: "thanos_receive_controller_hashrings_tenants",
+				Name: "thanos_receive_controller_hashring_tenants",
 				Help: "The number of tenants per hashring.",
 			},
 			[]string{"name"},

--- a/main.go
+++ b/main.go
@@ -361,7 +361,7 @@ func newController(klient kubernetes.Interface, logger log.Logger, o *options) *
 				Name: "thanos_receive_controller_hashrings_tenants",
 				Help: "The number of tenants per hashring.",
 			},
-			[]string{"tenant"},
+			[]string{"name"},
 		),
 	}
 }


### PR DESCRIPTION
This PR adds new metrics to monitor hash-rings.
It exposes the number of nodes and tenants per hash-ring.

\cc @squat @metalmatze