### PR TITLE
main.go: find hashring name in label, not sts name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,6 @@ spec:
 ```
 
 Finally, deploy StatefulSets of Thanos receivers labeled with `controller.receive.thanos.io=thanos-receive-controller`.
-The controller lists all of the StatefulSets with that label and matches their names to the hashring names in the configuration file.
+The controller lists all of the StatefulSets with that label and matches the value of their `controller.receive.thanos.io/hashring` labels to the hashring names in the configuration file.
 The endpoints for each hashring will be populated automatically by the controller and the complete configuration file will be placed in a ConfigMap named `thanos-receive-generated`.
 This configuration should be consumed as a ConfigMap volume by the Thanos receivers.

--- a/examples/simple.yaml
+++ b/examples/simple.yaml
@@ -61,6 +61,7 @@ metadata:
     app.kubernetes.io/name: thanos-receive
     app.kubernetes.io/instance: hashring0
     controller.receive.thanos.io: thanos-receive-controller
+    controller.receive.thanos.io/hashring: hashring0
 spec:
   replicas: 3
   selector:

--- a/main_test.go
+++ b/main_test.go
@@ -35,6 +35,29 @@ func TestController(t *testing.T) {
 			expected: []receive.HashringConfig{{Hashring: "hashring0"}},
 		},
 		{
+			name: "OneHashringOneStatefulSetNoMatch",
+			hashrings: []receive.HashringConfig{{
+				Hashring: "hashring0",
+				Tenants:  []string{"foo", "bar"},
+			}},
+			statefulsets: []*appsv1.StatefulSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:   "hashring0",
+						Labels: map[string]string{"a": "b"},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas:    intPointer(3),
+						ServiceName: "h0",
+					},
+				},
+			},
+			expected: []receive.HashringConfig{{
+				Hashring: "hashring0",
+				Tenants:  []string{"foo", "bar"},
+			}},
+		},
+		{
 			name: "OneHashringOneStatefulSet",
 			hashrings: []receive.HashringConfig{{
 				Hashring: "hashring0",
@@ -42,7 +65,13 @@ func TestController(t *testing.T) {
 			}},
 			statefulsets: []*appsv1.StatefulSet{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "hashring0", Labels: map[string]string{"a": "b"}},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "thanos-receive-hashring0",
+						Labels: map[string]string{
+							"a":              "b",
+							hashringLabelKey: "hashring0",
+						},
+					},
 					Spec: appsv1.StatefulSetSpec{
 						Replicas:    intPointer(3),
 						ServiceName: "h0",
@@ -67,14 +96,26 @@ func TestController(t *testing.T) {
 			}},
 			statefulsets: []*appsv1.StatefulSet{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "hashring0", Labels: map[string]string{"a": "b"}},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hashring0",
+						Labels: map[string]string{
+							"a":              "b",
+							hashringLabelKey: "hashring0",
+						},
+					},
 					Spec: appsv1.StatefulSetSpec{
 						Replicas:    intPointer(3),
 						ServiceName: "h0",
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "hashring123"},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hashring123",
+						Labels: map[string]string{
+							"a":              "b",
+							hashringLabelKey: "hashring123",
+						},
+					},
 					Spec: appsv1.StatefulSetSpec{
 						Replicas:    intPointer(123),
 						ServiceName: "h123",
@@ -101,14 +142,26 @@ func TestController(t *testing.T) {
 			}},
 			statefulsets: []*appsv1.StatefulSet{
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "hashring0", Labels: map[string]string{"a": "b"}},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hashring0",
+						Labels: map[string]string{
+							"a":              "b",
+							hashringLabelKey: "hashring0",
+						},
+					},
 					Spec: appsv1.StatefulSetSpec{
 						Replicas:    intPointer(3),
 						ServiceName: "h0",
 					},
 				},
 				{
-					ObjectMeta: metav1.ObjectMeta{Name: "hashring1", Labels: map[string]string{"a": "b"}},
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hashring1",
+						Labels: map[string]string{
+							"a":              "b",
+							hashringLabelKey: "hashring1",
+						},
+					},
 					Spec: appsv1.StatefulSetSpec{
 						Replicas:    intPointer(2),
 						ServiceName: "h1",


### PR DESCRIPTION
This commit modifies the controller to match statefulsets to hashrings
using a label rather than the statefulset name. This is important
because resource names are tied to infrastructure logic, not business
logic. Furthermore, most thanos-receive statefulsets names will always
have a `thanos-receive-` prefix, meaning that every hashring name would
also have to have that prefix. This change allows us to decouple
infrastructure and business.

cc @metalmatze @kakkoyun 