### PR TITLE
main: use statefulset name in endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -498,7 +498,7 @@ func (c *controller) populate(hashrings []receive.HashringConfig, statefulsets m
 				endpoints = append(endpoints,
 					fmt.Sprintf("%s://%s-%d.%s.%s.svc.%s:%d/%s",
 						c.options.scheme,
-						h.Hashring,
+						sts.Name,
 						i,
 						sts.Spec.ServiceName,
 						c.options.namespace,

--- a/main_test.go
+++ b/main_test.go
@@ -82,9 +82,9 @@ func TestController(t *testing.T) {
 				Hashring: "hashring0",
 				Tenants:  []string{"foo", "bar"},
 				Endpoints: []string{
-					"http://hashring0-0.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://hashring0-1.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://hashring0-2.h0.namespace.svc.cluster.local:19291/api/v1/receive",
+					"http://thanos-receive-hashring0-0.h0.namespace.svc.cluster.local:19291/api/v1/receive",
+					"http://thanos-receive-hashring0-1.h0.namespace.svc.cluster.local:19291/api/v1/receive",
+					"http://thanos-receive-hashring0-2.h0.namespace.svc.cluster.local:19291/api/v1/receive",
 				},
 			}},
 		},


### PR DESCRIPTION
We need to use the statefulset name, not the hashring name in the DNS
name.

cc @metalmatze @aditya-konarde 