### PR TITLE
Add kubernetes resource manifets

### DIFF
--- a/examples/manifests/thanos-receive-controller-configmap.yaml
+++ b/examples/manifests/thanos-receive-controller-configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  hashrings.json: |-
+    [
+      {
+        "hashring": "default",
+        "tenants": [
+
+        ]
+      }
+    ]
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/name: thanos-receive-controller
+  name: observatorium-tenants
+  namespace: observatorium

--- a/examples/manifests/thanos-receive-controller-deployment.yaml
+++ b/examples/manifests/thanos-receive-controller-deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: thanos-receive-controller
+  name: thanos-receive-controller
+  namespace: observatorium
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: thanos-receive-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: thanos-receive-controller
+    spec:
+      containers:
+      - args:
+        - --configmap-name=observatorium-tenants
+        - --configmap-generated-name=observatorium-tenants-generated
+        - --file-name=hashrings.json
+        - --namespace=$(NAMESPACE)
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: quay.io/observatorium/thanos-receive-controller:master-2019-08-09-c8204c0
+        name: thanos-receive-controller
+        ports:
+        - containerPort: 8080
+          name: http
+      serviceAccount: thanos-receive-controller

--- a/examples/manifests/thanos-receive-controller-role.yaml
+++ b/examples/manifests/thanos-receive-controller-role.yaml
@@ -1,0 +1,24 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: thanos-receive-controller
+  namespace: observatorium
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - list
+  - watch
+  - get
+  - create
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - list
+  - watch
+  - get

--- a/examples/manifests/thanos-receive-controller-roleBinding.yaml
+++ b/examples/manifests/thanos-receive-controller-roleBinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: thanos-receive-controller
+  namespace: observatorium
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: thanos-receive-controller
+subjects:
+- kind: ServiceAccount
+  name: thanos-receive-controller
+  namespace: observatorium

--- a/examples/manifests/thanos-receive-controller-service.yaml
+++ b/examples/manifests/thanos-receive-controller-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: thanos-receive-controller
+  name: thanos-receive-controller
+  namespace: observatorium
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    app.kubernetes.io/name: thanos-receive-controller

--- a/examples/manifests/thanos-receive-controller-serviceAccount.yaml
+++ b/examples/manifests/thanos-receive-controller-serviceAccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: thanos-receive-controller
+  namespace: observatorium

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -1,6 +1,16 @@
 {
     "dependencies": [
         {
+            "name": "ksonnet",
+            "source": {
+                "git": {
+                    "remote": "https://github.com/ksonnet/ksonnet-lib",
+                    "subdir": ""
+                }
+            },
+            "version": "0d2f82676817bbf9e4acf6495b2090205f323b9f"
+        },
+        {
             "name": "thanos-receive-controller-mixin",
             "source": {
                 "local": {

--- a/jsonnet/lib/thanos-receive-controller.libsonnet
+++ b/jsonnet/lib/thanos-receive-controller.libsonnet
@@ -1,0 +1,106 @@
+local k = import 'ksonnet/ksonnet.beta.4/k.libsonnet';
+
+{
+  _config+:: {
+    namespace:: 'observatorium',
+    version:: 'master-2019-08-09-c8204c0',
+    imageRepo:: 'quay.io/observatorium/thanos-receive-controller',
+  },
+  thanos+:: {
+    receiveController: {
+      serviceAccount:
+        local sa = k.core.v1.serviceAccount;
+
+        sa.new() +
+        sa.mixin.metadata.withName('thanos-receive-controller') +
+        sa.mixin.metadata.withNamespace($._config.namespace),
+
+      role:
+        local role = k.rbac.v1.role;
+        local rules = role.rulesType;
+
+        role.new() +
+        role.mixin.metadata.withName('thanos-receive-controller') +
+        role.mixin.metadata.withNamespace($._config.namespace) +
+        role.withRules([
+          rules.new() +
+          rules.withApiGroups(['']) +
+          rules.withResources([
+            'configmaps',
+          ]) +
+          rules.withVerbs(['list', 'watch', 'get', 'create', 'update']),
+          rules.new() +
+          rules.withApiGroups(['apps']) +
+          rules.withResources([
+            'statefulsets',
+          ]) +
+          rules.withVerbs(['list', 'watch', 'get']),
+        ]),
+
+      roleBinding:
+        local rb = k.rbac.v1.roleBinding;
+
+        rb.new() +
+        rb.mixin.metadata.withName('thanos-receive-controller') +
+        rb.mixin.metadata.withNamespace($._config.namespace) +
+        rb.mixin.roleRef.withApiGroup('rbac.authorization.k8s.io') +
+        rb.mixin.roleRef.withName($.thanos.receiveController.role.metadata.name) +
+        rb.mixin.roleRef.mixinInstance({ kind: 'Role' }) +
+        rb.withSubjects([{
+          kind: 'ServiceAccount',
+          name: $.thanos.receiveController.serviceAccount.metadata.name,
+          namespace: $.thanos.receiveController.serviceAccount.metadata.namespace,
+        }]),
+
+      configmap:
+        local configmap = k.core.v1.configMap;
+
+        configmap.new() +
+        configmap.mixin.metadata.withName('observatorium-tenants') +
+        configmap.mixin.metadata.withNamespace($._config.namespace) +
+        configmap.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.receiveController.deployment.metadata.name }) +
+        configmap.withData({
+          'hashrings.json': std.manifestJsonEx((import '../tenants.libsonnet'), '  '),
+        }),
+
+      service:
+        local service = k.core.v1.service;
+        local ports = service.mixin.spec.portsType;
+
+        service.new(
+          'thanos-receive-controller',
+          $.thanos.receiveController.deployment.metadata.labels,
+          [
+            ports.newNamed('http', 8080, 8080),
+          ],
+        ) +
+        service.mixin.metadata.withNamespace($._config.namespace) +
+        service.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.receiveController.deployment.metadata.name }),
+
+      deployment:
+        local deployment = k.apps.v1.deployment;
+        local container = deployment.mixin.spec.template.spec.containersType;
+        local containerPort = container.portsType;
+        local env = container.envType;
+
+        local c =
+          container.new($.thanos.receiveController.deployment.metadata.name, '%s:%s' % [$._config.imageRepo, $._config.version]) +
+          container.withArgs([
+            '--configmap-name=%s' % $.thanos.receiveController.configmap.metadata.name,
+            '--configmap-generated-name=%s-generated' % $.thanos.receiveController.configmap.metadata.name,
+            '--file-name=hashrings.json',
+            '--namespace=$(NAMESPACE)',
+          ]) + container.withEnv([
+            env.fromFieldPath('NAMESPACE', 'metadata.namespace'),
+          ]) + container.withPorts(
+            containerPort.newNamed(8080, 'http')
+          );
+
+        deployment.new('thanos-receive-controller', 1, c, $.thanos.receiveController.deployment.metadata.labels) +
+        deployment.mixin.metadata.withNamespace($._config.namespace) +
+        deployment.mixin.metadata.withLabels({ 'app.kubernetes.io/name': $.thanos.receiveController.deployment.metadata.name }) +
+        deployment.mixin.spec.template.spec.withServiceAccount($.thanos.receiveController.serviceAccount.metadata.name) +
+        deployment.mixin.spec.selector.withMatchLabels($.thanos.receiveController.deployment.metadata.labels),
+    },
+  },
+}

--- a/jsonnet/main.jsonnet
+++ b/jsonnet/main.jsonnet
@@ -1,0 +1,3 @@
+local app = import 'lib/thanos-receive-controller.libsonnet';
+
+{ ['thanos-receive-controller-' + name]: app.thanos.receiveController[name] for name in std.objectFields(app.thanos.receiveController) }

--- a/jsonnet/tenants.libsonnet
+++ b/jsonnet/tenants.libsonnet
@@ -1,0 +1,11 @@
+[
+  {
+    hashring: 'default',
+    replicas:: 3,
+    tenants: [
+      // Match all for now
+      // 'foo',
+      // 'bar',
+    ],
+  },
+]


### PR DESCRIPTION
This PR moves observatorium/configuration/components/thanos-receive-controller.libsonnet to the repo, and adds simple manifest generation.

cc @squat @metalmatze 