### PR TITLE
Configmap updates

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,3 +10,6 @@ linters-settings:
     exclude: .errcheck_excludes.txt
   lll:
     line-length: 200
+  funlen:
+    lines: 210
+    statements: 50

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ jsonnet-vendor: jsonnet/jsonnetfile.json
 
 .PHONY: fmt
 fmt:
-	@fmt_res=$$(gofmt -d -s $$(find . -type f -name '*.go' -not -path './vendor/*')); if [ -n "$$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$$fmt_res"; exit 1; fi
+	@fmt_res=$$(gofmt -d -s $$(find . -type f -name '*.go' -not -path './vendor/*' -not -path './jsonnet/vendor/*')); if [ -n "$$fmt_res" ]; then printf '\nGofmt found style issues. Please check the reported issues\nand fix them if necessary before submitting the code for review:\n\n%s' "$$fmt_res"; exit 1; fi
 	@echo ${JSONNET_SRC} | xargs -n 1 -- $(JSONNET_FMT) -i
 
 .PHONY: lint

--- a/examples/alerts.yaml
+++ b/examples/alerts.yaml
@@ -29,18 +29,6 @@ groups:
     for: 5m
     labels:
       severity: warning
-  - alert: ThanosReceiveConfigStale
-    annotations:
-      message: The configuration of the instances of Thanos Receive are stale compare
-        to controller.
-    expr: |
-      avg(thanos_receive_config_last_reload_success_timestamp_seconds{job=~"thanos-receive.*"}) by (namespace, job)
-        <
-      on(namespace)
-      thanos_receive_controller_configmap_last_reload_success_timestamp_seconds{job=~"thanos-receive-controller.*"}
-    for: 5m
-    labels:
-      severity: critical
   - alert: ThanosReceiveConfigInconsistent
     annotations:
       message: The configuration of the instances of Thanos Receive `{{$labels.job}}`

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ replace github.com/prometheus/prometheus => github.com/prometheus/prometheus v0.
 
 require (
 	github.com/go-kit/kit v0.9.0
+	github.com/google/go-cmp v0.3.1
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/googleapis/gnostic v0.3.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -121,6 +121,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
+github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf/go.mod h1:HP5RmnzzSNb993RKQDq4+1A4ia9nllfqcQFTQJedwGI=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=

--- a/jsonnet/thanos-receive-controller-mixin/alerts/alerts.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/alerts/alerts.libsonnet
@@ -41,22 +41,6 @@
             },
           },
           {
-            alert: 'ThanosReceiveConfigStale',
-            annotations: {
-              message: 'The configuration of the instances of Thanos Receive are stale compare to controller.',
-            },
-            expr: |||
-              avg(thanos_receive_config_last_reload_success_timestamp_seconds{%(thanosReceiveSelector)s}) by (namespace, job)
-                <
-              on(namespace)
-              thanos_receive_controller_configmap_last_reload_success_timestamp_seconds{%(thanosReceiveControllerSelector)s}
-            ||| % $._config,
-            'for': '5m',
-            labels: {
-              severity: 'critical',
-            },
-          },
-          {
             alert: 'ThanosReceiveConfigInconsistent',
             annotations: {
               message: 'The configuration of the instances of Thanos Receive `{{$labels.job}}` are out of sync.',

--- a/main.go
+++ b/main.go
@@ -111,14 +111,14 @@ func main() {
 
 	var g run.Group
 	{
-		// Signal chans must be buffered.
+		// Signal channels must be buffered.
 		sig := make(chan os.Signal, 1)
 		g.Add(func() error {
 			signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
 			<-sig
 			return nil
 		}, func(_ error) {
-			level.Info(logger).Log("msg", "caught interrrupt")
+			level.Info(logger).Log("msg", "caught interrupt")
 			close(sig)
 		})
 	}

--- a/main.go
+++ b/main.go
@@ -535,18 +535,24 @@ func (c *controller) saveHashring(hashring []receive.HashringConfig) error {
 	}
 
 	c.configmapChangeAttempts.Inc()
-	_, err = c.klient.CoreV1().ConfigMaps(c.options.namespace).Get(c.options.configMapGeneratedName, metav1.GetOptions{})
+	gcm, err := c.klient.CoreV1().ConfigMaps(c.options.namespace).Get(c.options.configMapGeneratedName, metav1.GetOptions{})
 	if kerrors.IsNotFound(err) {
 		_, err = c.klient.CoreV1().ConfigMaps(c.options.namespace).Create(cm)
 		if err != nil {
 			c.configmapChangeErrors.WithLabelValues(create).Inc()
 			return err
 		}
+		c.configmapLastSuccessfulChangeTime.Set(float64(time.Now().Unix()))
+		c.configmapHash.Set(hashAsMetricValue(buf))
 		return nil
 	}
 	if err != nil {
 		c.configmapChangeErrors.WithLabelValues(other).Inc()
 		return err
+	}
+
+	if gcm.Data[c.options.fileName] == cm.Data[c.options.fileName] {
+		return nil
 	}
 
 	_, err = c.klient.CoreV1().ConfigMaps(c.options.namespace).Update(cm)

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/improbable-eng/thanos/pkg/receive"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -185,12 +186,11 @@ func TestController(t *testing.T) {
 			}},
 		},
 	} {
+		name := tt.name
 		hashrings := tt.hashrings
 		statefulsets := tt.statefulsets
 		expected := tt.expected
-		name := tt.name
 		t.Run(name, func(t *testing.T) {
-			klient := fake.NewSimpleClientset()
 			opts := &options{
 				labelKey:               "a",
 				labelValue:             "b",
@@ -203,49 +203,21 @@ func TestController(t *testing.T) {
 				port:                   19291,
 				scheme:                 "http",
 			}
-			c := newController(klient, nil, opts)
-			stop := make(chan struct{})
-			defer close(stop)
 
-			//nolint:staticcheck
-			go func() {
-				if err := c.run(stop); err != nil {
-					t.Fatalf("got unexpected error: %v", err)
-				}
-			}()
+			klient := fake.NewSimpleClientset()
+			_, cleanUp := setup(t, klient, opts)
+			defer cleanUp()
 
-			buf, err := json.Marshal(hashrings)
-			if err != nil {
-				t.Fatalf("got unexpected error marshaling initial hashrings: %v", err)
-			}
-			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      opts.configMapName,
-					Namespace: opts.namespace,
-				},
-				Data: map[string]string{
-					opts.fileName: string(buf),
-				},
-				BinaryData: nil,
-			}
-			if _, err := klient.CoreV1().ConfigMaps(opts.namespace).Create(cm); err != nil {
-				t.Fatalf("got unexpected error creating ConfigMap: %v", err)
-			}
-
-			for _, sts := range statefulsets {
-				if _, err := klient.AppsV1().StatefulSets(opts.namespace).Create(sts); err != nil {
-					t.Fatalf("got unexpected error creating StatefulSet: %v", err)
-				}
-			}
+			_ = createOriginalConfigMap(t, klient, opts, hashrings, statefulsets)
 
 			// Reconciliation is async, so we need to wait a bit.
 			<-time.After(500 * time.Millisecond)
-			cm, err = klient.CoreV1().ConfigMaps(opts.namespace).Get(opts.configMapGeneratedName, metav1.GetOptions{})
+			cm, err := klient.CoreV1().ConfigMaps(opts.namespace).Get(opts.configMapGeneratedName, metav1.GetOptions{})
 			if err != nil {
 				t.Fatalf("got unexpected error getting ConfigMap: %v", err)
 			}
 
-			buf, err = json.Marshal(expected)
+			buf, err := json.Marshal(expected)
 			if err != nil {
 				t.Fatalf("got unexpected error marshaling expected hashrings: %v", err)
 			}
@@ -255,4 +227,165 @@ func TestController(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestControllerConfigmapUpdate(t *testing.T) {
+	originalHashrings := []receive.HashringConfig{{
+		Hashring: "hashring0",
+		Tenants:  []string{"foo", "bar"},
+	}}
+	intendedLabels := map[string]string{
+		"manuel": "change",
+	}
+
+	for _, tt := range []struct {
+		name            string
+		hashrings       []receive.HashringConfig
+		labels          map[string]string
+		shouldBeUpdated bool
+	}{
+		{
+			name: "ConfigMapWithHashringChange",
+			hashrings: []receive.HashringConfig{{
+				Hashring: "hashring0",
+				Tenants:  []string{"foo", "bar", "baz"},
+			}},
+			labels:          intendedLabels,
+			shouldBeUpdated: true,
+		},
+		{
+			name:            "ConfigMapWithOtherChange",
+			hashrings:       originalHashrings,
+			labels:          intendedLabels,
+			shouldBeUpdated: false,
+		},
+	} {
+		name := tt.name
+		hashrings := tt.hashrings
+		labels := tt.labels
+		shouldBeUpdated := tt.shouldBeUpdated
+		t.Run(name, func(t *testing.T) {
+			opts := &options{
+				labelKey:               "a",
+				labelValue:             "b",
+				fileName:               "hashrings.json",
+				clusterDomain:          "cluster.local",
+				configMapName:          "original",
+				configMapGeneratedName: "generated",
+				namespace:              "namespace",
+				path:                   "/api/v1/receive",
+				port:                   19291,
+				scheme:                 "http",
+			}
+			klient := fake.NewSimpleClientset()
+			_, cleanUp := setup(t, klient, opts)
+			defer cleanUp()
+
+			cm := createOriginalConfigMap(t, klient, opts,
+				originalHashrings,
+				[]*appsv1.StatefulSet{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "thanos-receive-hashring0",
+							Labels: map[string]string{
+								"a":              "b",
+								hashringLabelKey: "hashring0",
+							},
+						},
+						Spec: appsv1.StatefulSetSpec{
+							Replicas:    intPointer(3),
+							ServiceName: "h0",
+						},
+					},
+				})
+
+			// Reconciliation is async, so we need to wait a bit.
+			<-time.After(500 * time.Millisecond)
+			gcm, err := klient.CoreV1().ConfigMaps(opts.namespace).Get(opts.configMapGeneratedName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("got unexpected error getting ConfigMap: %v", err)
+			}
+
+			// Manually change properties of generated configmap.
+			gcm.Labels = labels
+			if gcm, err = klient.CoreV1().ConfigMaps(opts.namespace).Update(gcm); err != nil {
+				t.Fatalf("got unexpected error updating ConfigMap: %v", err)
+			}
+
+			buf, err := json.Marshal(hashrings)
+			if err != nil {
+				t.Fatalf("got unexpected error marshaling initial hashrings: %v", err)
+			}
+			cm.Data = map[string]string{
+				opts.fileName: string(buf),
+			}
+			if cm, err = klient.CoreV1().ConfigMaps(opts.namespace).Update(cm); err != nil {
+				t.Fatalf("got unexpected error updating ConfigMap: %v", err)
+			}
+
+			// Reconciliation is async, so we need to wait a bit.
+			<-time.After(500 * time.Millisecond)
+			gcm, err = klient.CoreV1().ConfigMaps(opts.namespace).Get(opts.configMapGeneratedName, metav1.GetOptions{})
+			if err != nil {
+				t.Fatalf("got unexpected error getting ConfigMap: %v", err)
+			}
+
+			if shouldBeUpdated {
+				// Generated configmap should be overfidden by default properties.
+				if cmp.Equal(gcm.Labels, map[string]string{}) {
+					t.Errorf("generated configmap should have been updated\ncase:\t%q\noriginal:\t%+v\ngenerated:\t%+v\n", name, cm.Labels, gcm.Labels)
+				}
+			} else {
+				// Generated configmap should preserve changes.
+				if !cmp.Equal(gcm.Labels, labels) {
+					t.Errorf("generated configmap should NOT have been updated\ncase:\t%q\noriginal:\t%+v\ngenerated:\t%+v\n", name, cm.Labels, gcm.Labels)
+				}
+			}
+		})
+	}
+}
+
+func setup(t *testing.T, klient *fake.Clientset, opts *options) (*controller, func()) {
+	c := newController(klient, nil, opts)
+	stop := make(chan struct{})
+
+	//nolint:staticcheck
+	go func() {
+		if err := c.run(stop); err != nil {
+			t.Fatalf("got unexpected error: %v", err)
+		}
+	}()
+
+	return c, func() {
+		close(stop)
+	}
+}
+
+func createOriginalConfigMap(t *testing.T, klient *fake.Clientset, opts *options, hashrings []receive.HashringConfig, statefulsets []*appsv1.StatefulSet) *corev1.ConfigMap {
+	buf, err := json.Marshal(hashrings)
+	if err != nil {
+		t.Fatalf("got unexpected error marshaling initial hashrings: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      opts.configMapName,
+			Namespace: opts.namespace,
+		},
+		Data: map[string]string{
+			opts.fileName: string(buf),
+		},
+		BinaryData: nil,
+	}
+	if _, err := klient.CoreV1().ConfigMaps(opts.namespace).Create(cm); err != nil {
+		t.Fatalf("got unexpected error creating ConfigMap: %v", err)
+	}
+
+	for _, sts := range statefulsets {
+		if _, err := klient.AppsV1().StatefulSets(opts.namespace).Create(sts); err != nil {
+			t.Fatalf("got unexpected error creating StatefulSet: %v", err)
+		}
+	}
+
+	return cm
 }

--- a/tests.yaml
+++ b/tests.yaml
@@ -35,10 +35,7 @@ tests:
   - eval_time: 4m
     alertname: ThanosReceiveControllerConfigmapChangeErrorRate
   - eval_time: 4m
-    alertname: ThanosReceiveConfigStale
-  - eval_time: 4m
     alertname: ThanosReceiveConfigInconsistent
-
   - eval_time: 6m
     alertname: ThanosReceiveControllerReconcileErrorRate
     exp_alerts:
@@ -53,14 +50,6 @@ tests:
         severity: warning
       exp_annotations:
         message: 'Thanos Receive Controller failing to refresh configmap, 10% of attempts failed.'
-  - eval_time: 6m
-    alertname: ThanosReceiveConfigStale
-    exp_alerts:
-    - exp_labels:
-        severity: critical
-        namespace: 'production'
-      exp_annotations:
-        message: 'The configuration of the instances of Thanos Receive are stale compare to controller.'
   - eval_time: 6m
     alertname: ThanosReceiveConfigInconsistent
     exp_alerts:


### PR DESCRIPTION
This PR,

* removes redundant alert for stale config changes
* ensures metrics correctly incremented when configmap first created
* ensures configmap does not get updated if hashring has not changed
* introduces a couple of test helper functions