### PR TITLE
main.go: always set hash metric

### DIFF
--- a/main.go
+++ b/main.go
@@ -534,6 +534,7 @@ func (c *controller) saveHashring(hashring []receive.HashringConfig) error {
 		BinaryData: nil,
 	}
 
+	c.configmapHash.Set(hashAsMetricValue(buf))
 	c.configmapChangeAttempts.Inc()
 	gcm, err := c.klient.CoreV1().ConfigMaps(c.options.namespace).Get(c.options.configMapGeneratedName, metav1.GetOptions{})
 	if kerrors.IsNotFound(err) {
@@ -543,7 +544,6 @@ func (c *controller) saveHashring(hashring []receive.HashringConfig) error {
 			return err
 		}
 		c.configmapLastSuccessfulChangeTime.Set(float64(time.Now().Unix()))
-		c.configmapHash.Set(hashAsMetricValue(buf))
 		return nil
 	}
 	if err != nil {
@@ -562,7 +562,6 @@ func (c *controller) saveHashring(hashring []receive.HashringConfig) error {
 	}
 
 	c.configmapLastSuccessfulChangeTime.Set(float64(time.Now().Unix()))
-	c.configmapHash.Set(hashAsMetricValue(buf))
 	return nil
 }
 


### PR DESCRIPTION
This commit ensures that the hash metric is always set, this way if the
controller is re-started after the configmap is already correctly
deployed, the metric will be set and no alert will fire.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @aditya-konarde 