### PR TITLE
main.go: add missing pprof handlers

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,6 +150,10 @@ func main() {
 		router := http.NewServeMux()
 		router.Handle("/metrics", promhttp.InstrumentMetricHandler(reg, promhttp.HandlerFor(reg, promhttp.HandlerOpts{})))
 		router.HandleFunc("/debug/pprof/", pprof.Index)
+		router.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		router.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		router.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		router.HandleFunc("/debug/pprof/trace", pprof.Trace)
 
 		srv := &http.Server{Addr: config.InternalAddr, Handler: router}
 


### PR DESCRIPTION
pprof.Index automatically delegates to the profile handlers accessible
via `pprof.Handler(...)`, but not ALL profiles. This commit adds support
for the missing profiles.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

reference: https://golang.org/src/net/http/pprof/pprof.go?s=8862:9042#L260

cc @kakkoyun @metalmatze 