### PR TITLE
main.go: controller generate gRPC endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,7 +62,6 @@ func main() {
 		ConfigMapName          string
 		ConfigMapGeneratedName string
 		FileName               string
-		Path                   string
 		Port                   int
 		Scheme                 string
 		InternalAddr           string
@@ -75,8 +74,7 @@ func main() {
 	flag.StringVar(&config.ConfigMapName, "configmap-name", "", "The name of the original ConfigMap containing the hashring tenant configuration")
 	flag.StringVar(&config.ConfigMapGeneratedName, "configmap-generated-name", "", "The name of the generated and populated ConfigMap")
 	flag.StringVar(&config.FileName, "file-name", "", "The name of the configuration file in the ConfigMap")
-	flag.StringVar(&config.Path, "path", "/api/v1/receive", "The URL path on which receive components accept write requests")
-	flag.IntVar(&config.Port, "port", 19291, "The port on which receive components are listening for write requests")
+	flag.IntVar(&config.Port, "port", 10901, "The port on which receive components are listening for write requests")
 	flag.StringVar(&config.Scheme, "scheme", "http", "The URL scheme on which receive components accept write requests")
 	flag.StringVar(&config.InternalAddr, "internal-addr", ":8080", "The address on which internal server runs")
 	flag.Parse()
@@ -129,7 +127,6 @@ func main() {
 			configMapGeneratedName: config.ConfigMapGeneratedName,
 			fileName:               config.FileName,
 			namespace:              config.Namespace,
-			path:                   config.Path,
 			port:                   config.Port,
 			scheme:                 config.Scheme,
 			labelKey:               labelKey,
@@ -296,7 +293,6 @@ type options struct {
 	configMapGeneratedName string
 	fileName               string
 	namespace              string
-	path                   string
 	port                   int
 	scheme                 string
 	labelKey               string
@@ -503,15 +499,14 @@ func (c *controller) populate(hashrings []receive.HashringConfig, statefulsets m
 			var endpoints []string
 			for i := 0; i < int(*sts.Spec.Replicas); i++ {
 				endpoints = append(endpoints,
-					fmt.Sprintf("%s://%s-%d.%s.%s.svc.%s:%d/%s",
-						c.options.scheme,
+					fmt.Sprintf("%s-%d.%s.%s.svc.%s:%d",
 						sts.Name,
 						i,
 						sts.Spec.ServiceName,
 						c.options.namespace,
 						c.options.clusterDomain,
 						c.options.port,
-						strings.TrimPrefix(c.options.path, "/")),
+					),
 				)
 			}
 			hashrings[i].Endpoints = endpoints

--- a/main_test.go
+++ b/main_test.go
@@ -84,9 +84,9 @@ func TestController(t *testing.T) {
 				Hashring: "hashring0",
 				Tenants:  []string{"foo", "bar"},
 				Endpoints: []string{
-					"http://thanos-receive-hashring0-0.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://thanos-receive-hashring0-1.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://thanos-receive-hashring0-2.h0.namespace.svc.cluster.local:19291/api/v1/receive",
+					"thanos-receive-hashring0-0.h0.namespace.svc.cluster.local:10901",
+					"thanos-receive-hashring0-1.h0.namespace.svc.cluster.local:10901",
+					"thanos-receive-hashring0-2.h0.namespace.svc.cluster.local:10901",
 				},
 			}},
 		},
@@ -128,9 +128,9 @@ func TestController(t *testing.T) {
 				Hashring: "hashring0",
 				Tenants:  []string{"foo", "bar"},
 				Endpoints: []string{
-					"http://hashring0-0.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://hashring0-1.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://hashring0-2.h0.namespace.svc.cluster.local:19291/api/v1/receive",
+					"hashring0-0.h0.namespace.svc.cluster.local:10901",
+					"hashring0-1.h0.namespace.svc.cluster.local:10901",
+					"hashring0-2.h0.namespace.svc.cluster.local:10901",
 				},
 			}},
 		},
@@ -174,15 +174,15 @@ func TestController(t *testing.T) {
 				Hashring: "hashring0",
 				Tenants:  []string{"foo", "bar"},
 				Endpoints: []string{
-					"http://hashring0-0.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://hashring0-1.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://hashring0-2.h0.namespace.svc.cluster.local:19291/api/v1/receive",
+					"hashring0-0.h0.namespace.svc.cluster.local:10901",
+					"hashring0-1.h0.namespace.svc.cluster.local:10901",
+					"hashring0-2.h0.namespace.svc.cluster.local:10901",
 				},
 			}, {
 				Hashring: "hashring1",
 				Endpoints: []string{
-					"http://hashring1-0.h1.namespace.svc.cluster.local:19291/api/v1/receive",
-					"http://hashring1-1.h1.namespace.svc.cluster.local:19291/api/v1/receive",
+					"hashring1-0.h1.namespace.svc.cluster.local:10901",
+					"hashring1-1.h1.namespace.svc.cluster.local:10901",
 				},
 			}},
 		},
@@ -200,8 +200,7 @@ func TestController(t *testing.T) {
 				configMapName:          "original",
 				configMapGeneratedName: "generated",
 				namespace:              "namespace",
-				path:                   "/api/v1/receive",
-				port:                   19291,
+				port:                   10901,
 				scheme:                 "http",
 			}
 			klient := fake.NewSimpleClientset()
@@ -234,9 +233,9 @@ func TestControllerConfigmapUpdate(t *testing.T) {
 		Hashring: "hashring0",
 		Tenants:  []string{"foo", "bar"},
 		Endpoints: []string{
-			"http://thanos-receive-hashring0-0.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-			"http://thanos-receive-hashring0-1.h0.namespace.svc.cluster.local:19291/api/v1/receive",
-			"http://thanos-receive-hashring0-2.h0.namespace.svc.cluster.local:19291/api/v1/receive",
+			"thanos-receive-hashring0-0.h0.namespace.svc.cluster.local:10901",
+			"thanos-receive-hashring0-1.h0.namespace.svc.cluster.local:10901",
+			"thanos-receive-hashring0-2.h0.namespace.svc.cluster.local:10901",
 		},
 	}}
 	intendedLabels := map[string]string{
@@ -278,8 +277,7 @@ func TestControllerConfigmapUpdate(t *testing.T) {
 				configMapName:          "original",
 				configMapGeneratedName: "generated",
 				namespace:              "namespace",
-				path:                   "/api/v1/receive",
-				port:                   19291,
+				port:                   10901,
 				scheme:                 "http",
 			}
 			klient := fake.NewSimpleClientset()


### PR DESCRIPTION
This commit updates the controller to generate gRPC endpoints rather
than HTTP endpoints, following
https://github.com/thanos-io/thanos/pull/1970.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>

cc @kakkoyun @metalmatze 