### PR TITLE
Show the rate of reconciles and configmap changes

### DIFF
--- a/examples/dashboards/receive-controller.json
+++ b/examples/dashboards/receive-controller.json
@@ -14,14 +14,12 @@
          "height": "250px",
          "panels": [
             {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
+               "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "fill": 10,
+               "fill": 1,
                "id": 1,
                "legend": {
                   "avg": false,
@@ -33,7 +31,7 @@
                   "values": false
                },
                "lines": true,
-               "linewidth": 0,
+               "linewidth": 1,
                "links": [ ],
                "nullPointMode": "null as zero",
                "percentage": false,
@@ -43,15 +41,15 @@
                "seriesOverrides": [ ],
                "spaceLength": 10,
                "span": 6,
-               "stack": true,
+               "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_receive_controller_reconcile_errors_total{namespace=\"$namespace\",job=~\"thanos-receive-controller.*\"}[$interval])) / sum(rate(thanos_receive_controller_reconcile_attempts_total{namespace=\"$namespace\",job=~\"thanos-receive-controller.*\"}[$interval]))",
+                     "expr": "thanos_receive_controller_reconcile_attempts_total{namespace=\"$namespace\",job=~\"thanos-receive-controller.*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
+                     "legendFormat": "rate",
+                     "legendLink": null,
                      "step": 10
                   }
                ],
@@ -74,7 +72,7 @@
                },
                "yaxes": [
                   {
-                     "format": "percentunit",
+                     "format": "short",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -180,14 +178,12 @@
          "height": "250px",
          "panels": [
             {
-               "aliasColors": {
-                  "error": "#E24D42"
-               },
+               "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
                "datasource": "$datasource",
-               "fill": 10,
+               "fill": 1,
                "id": 3,
                "legend": {
                   "avg": false,
@@ -199,7 +195,7 @@
                   "values": false
                },
                "lines": true,
-               "linewidth": 0,
+               "linewidth": 1,
                "links": [ ],
                "nullPointMode": "null as zero",
                "percentage": false,
@@ -209,15 +205,15 @@
                "seriesOverrides": [ ],
                "spaceLength": 10,
                "span": 6,
-               "stack": true,
+               "stack": false,
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "sum(rate(thanos_receive_controller_configmap_change_errors_total{namespace=\"$namespace\",job=~\"thanos-receive-controller.*\"}[$interval])) / sum(rate(thanos_receive_controller_configmap_change_attempts_total{namespace=\"$namespace\",job=~\"thanos-receive-controller.*\"}[$interval]))",
+                     "expr": "thanos_receive_controller_configmap_change_attempts_total{namespace=\"$namespace\",job=~\"thanos-receive-controller.*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "error",
-                     "refId": "A",
+                     "legendFormat": "rate",
+                     "legendLink": null,
                      "step": 10
                   }
                ],
@@ -240,7 +236,7 @@
                },
                "yaxes": [
                   {
-                     "format": "percentunit",
+                     "format": "short",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/jsonnet/thanos-receive-controller-mixin/dashboards/dashboards.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/dashboards/dashboards.libsonnet
@@ -8,9 +8,9 @@ local g = import 'thanos-mixin/lib/thanos-grafana-builder/builder.libsonnet';
         g.row('Reconcile Attempts')
         .addPanel(
           g.panel('Rate') +
-          g.qpsErrTotalPanel(
-            'thanos_receive_controller_reconcile_errors_total{namespace="$namespace",%(thanosReceiveControllerSelector)s}' % $._config,
+          g.queryPanel(
             'thanos_receive_controller_reconcile_attempts_total{namespace="$namespace",%(thanosReceiveControllerSelector)s}' % $._config,
+            'rate'
           )
         )
         .addPanel(
@@ -27,9 +27,9 @@ local g = import 'thanos-mixin/lib/thanos-grafana-builder/builder.libsonnet';
         g.row('Configmap Changes')
         .addPanel(
           g.panel('Rate') +
-          g.qpsErrTotalPanel(
-            'thanos_receive_controller_configmap_change_errors_total{namespace="$namespace",%(thanosReceiveControllerSelector)s}' % $._config,
+          g.queryPanel(
             'thanos_receive_controller_configmap_change_attempts_total{namespace="$namespace",%(thanosReceiveControllerSelector)s}' % $._config,
+            'rate',
           )
         )
         .addPanel(


### PR DESCRIPTION
The rate should show a constant rate of reconciles and changes. Next to those 2 graphs we still have an extra error graph. 

![Screenshot from 2020-02-14 11-39-23](https://user-images.githubusercontent.com/872251/74524201-e0f53180-4f1e-11ea-8091-8c30d783cb87.png)
![Screenshot from 2020-02-14 11-40-37](https://user-images.githubusercontent.com/872251/74524204-e2bef500-4f1e-11ea-8b43-47140bf2aea5.png)
