### PR TITLE
mixin: Default dashboards to UTC

### DIFF
--- a/examples/dashboards/receive-controller.json
+++ b/examples/dashboards/receive-controller.json
@@ -963,7 +963,7 @@
          "30d"
       ]
    },
-   "timezone": "",
+   "timezone": "UTC",
    "title": "Thanos / Receive Controller",
    "uid": "858503cdeb29690fd8946e038f01ba85",
    "version": 0

--- a/jsonnet/jsonnetfile.json
+++ b/jsonnet/jsonnetfile.json
@@ -33,7 +33,7 @@
       "source": {
         "git": {
           "remote": "https://github.com/thanos-io/thanos",
-          "subdir": "mixin/thanos"
+          "subdir": "mixin"
         }
       },
       "version": "master",

--- a/jsonnet/thanos-receive-controller-mixin/dashboards/defaults.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/dashboards/defaults.libsonnet
@@ -8,7 +8,7 @@
   grafanaDashboards:: {
     [filename]: grafanaDashboards[filename] {
       uid: std.md5(filename),
-      timezone: '',
+      timezone: 'UTC',
       tags: $._config.grafanaThanos.dashboardTags,
 
       // Modify tooltip to only show a single value


### PR DESCRIPTION
Various tools in the SRE space use UTC as the default to make it
effortless during incidents to not have to calculate between timezones.
Just an example, both Prometheus and Thanos default to this behavior as
well. People can still override this in downstream usage, but I think we
should be promoting best practices.

@observatorium/maintainers 