### PR TITLE
Move to non-root container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM alpine
+FROM gcr.io/distroless/static:latest
 
 COPY thanos-receive-controller /usr/bin/thanos-receive-controller
+
+USER 65534
 
 ENTRYPOINT ["/usr/bin/thanos-receive-controller"]


### PR DESCRIPTION
Move to gcr.io/distroless/static image which has non-root user.

Signed-off-by: Alex Szakaly <alex.szakaly@gmail.com>

Fixes #56 