### PR TITLE
Update Hash ring only with the in-ready-status replicas of Statefulset

### DIFF
--- a/main.go
+++ b/main.go
@@ -518,7 +518,7 @@ func (c *controller) populate(hashrings []receive.HashringConfig, statefulsets m
 		if sts, exists := statefulsets[h.Hashring]; exists {
 			var endpoints []string
 
-			for i := 0; i < int(*sts.Spec.Replicas); i++ {
+			for i := 0; i < int(sts.Status.ReadyReplicas); i++ {
 				// If cluster domain is empty string we don't want dot after svc.
 				clusterDomain := ""
 				if c.options.clusterDomain != "" {


### PR DESCRIPTION
Currently Hash ring is getting updated based on the .spec of the statefulset that is being watched. There are few edge cases where Hash ring is updated pre maturely (eg: replicas take some time to come up) / Hash ring is updated with incorrect replicas if the scaling of statefulset would not succeed (eg: not enough resources on the cluster).  Downside of this behaviour is that requests to statefulsets like Thanos-default-receive result in temporary (with successful scaling up of a statefulset) / permanent (with unsuccessful scaling up of a statefulset) HTTP 500s.

This fix update Hash ring only with the replicas of the statefulset which are in 'Ready' status. 