### PR TITLE
Probe Statefulset Pods until healthy upon scale up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,9 @@ go 1.14
 require (
 	github.com/go-kit/kit v0.9.0
 	github.com/google/go-cmp v0.5.4
-	github.com/oklog/run v1.0.0
+	github.com/oklog/run v1.1.0
 	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/onsi/gomega v1.8.1 // indirect
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.5.0
 	github.com/thanos-io/thanos v0.12.0
 	k8s.io/api v0.0.0-20191115095533-47f6de673b26

--- a/go.sum
+++ b/go.sum
@@ -542,6 +542,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+
 github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86wM1zFnC6/uDBfZGNwB65O+pR2OFi5q/YQaEUid1qA=
 github.com/oklog/run v1.0.0 h1:Ru7dDtJNOyC66gQ5dQmaCa0qIsAUFY3sFpK1Xk8igrw=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v0.0.0-20170117200651-66bb6560562f/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/oklog/ulid v1.3.1 h1:EGfNDEx6MqHz8B3uNV6QAib1UR2Lm97sHi3ocA6ESJ4=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=


### PR DESCRIPTION
This is crucial to not send requests to receivers too early.
In combination with https://github.com/thanos-io/thanos/pull/3845 for quicker reloading of Thanos Receive Routes I was able to achieve > 99% availability in errors+latency while scaling up from 3 replicas to 20.

![2-receiver-route-improve-controller](https://user-images.githubusercontent.com/872251/112177824-8e924400-8bf9-11eb-87b4-7a2066e4d98b.png)
