### PR TITLE
Generated Hashring to contain only the statefulset replicas in the Ready status

### DIFF
--- a/main.go
+++ b/main.go
@@ -503,7 +503,7 @@ func (c *controller) sync() {
 		}
 
 		var endpoints []string
-		// Iterate over new replicas to wait until they are running
+		// Iterate over all the replicas to wait for 1-minute for any non-Ready replicas to reach Ready status.
 		for i := 0; i < int(*sts.Spec.Replicas); i++ {
 			start := time.Now()
 			podName := fmt.Sprintf("%s-%d", sts.Name, i)


### PR DESCRIPTION
Currently when the statefulset is [scaled](https://github.com/observatorium/thanos-receive-controller/blob/7770963ca21514a0c389822ee334d7d3f4e5faac/main.go#L511) (lower number to higher number),  pods are being checked to be in ready condition before the respective endpoints are considered to be part of Hashring configMap. However in [subsequent runs](https://github.com/observatorium/thanos-receive-controller/blob/7770963ca21514a0c389822ee334d7d3f4e5faac/main.go#L526) of  thanos-receiver-controller loop, the entire of statefulset spec. of replicas (intended # of replicas) is considered for Hashring generation.  This can be a problem if scale up fails to reach the intended # of replicas.

This PR :  

- ensures scale up of replicas (even if scale up does not reach intentended # of replicas ) result in generated Hashring to contain endpoints of replicas in the ready status
- removes separate logic for scaling up to make sure all the thanos-receive-controller runs 'checks for pods to be in ready status' before their service endpoints are added to the Hashring. 
- Update tests to make sure the path for 'checking for pods to be in ready status' is tested


