### PR TITLE
upgrade golang to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
+FROM golang:1.16-alpine3.12 as builder
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN apk update && apk upgrade && apk add --no-cache alpine-sdk
+
+RUN  make thanos-receive-controller
+
 FROM gcr.io/distroless/static:latest
 
-COPY thanos-receive-controller /usr/bin/thanos-receive-controller
+COPY --from=builder /workspace/thanos-receive-controller /usr/bin/thanos-receive-controller
 
 USER 65534
 


### PR DESCRIPTION
Golang versions 1.13 and 1.14 are no longer supported. For security compliance, we need to upgrade golang to 1.16.
Signed-off-by: Song Song Li <ssli@redhat.com>