### PR TITLE
Add permission to get pods to RBAC Role

### DIFF
--- a/examples/manifests/role.yaml
+++ b/examples/manifests/role.yaml
@@ -20,6 +20,12 @@ rules:
   - create
   - update
 - apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - statefulsets

--- a/jsonnet/lib/thanos-receive-controller.libsonnet
+++ b/jsonnet/lib/thanos-receive-controller.libsonnet
@@ -72,6 +72,11 @@ function(params) {
         verbs: ['list', 'watch', 'get', 'create', 'update'],
       },
       {
+        apiGroups: [''],
+        resources: ['pods'],
+        verbs: ['get'],
+      },
+      {
         apiGroups: ['apps'],
         resources: ['statefulsets'],
         verbs: ['list', 'watch', 'get'],


### PR DESCRIPTION
The `allow-only-ready-replicas` feature requires permission to get pods. Otherwise the following error occurs:

> failed polling until pod is ready" pod=thanos-receive-3 duration=4.340636ms err="pods " thanos-receive-3" is forbidden: User "system:serviceaccount:thanos:thanos-receive-controller" cannot get resource "pods" in API group "" in the namespace "thanos"

This PR adds the necessary permission to the example manifest, as well as the Jsonnet code.