### PR TITLE
Support updating the hashring during scaledown/disruptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,13 @@ The endpoints for each hashring will be populated automatically by the controlle
 This configuration should be consumed as a ConfigMap volume by the Thanos receivers.
 
 ## About the `--allow-only-ready-replicas` flag
-By default, upon a scale up, the controller adds all new receiver replicas into the hashring as soon as they are in a _running_ state. However, this means the new replicas will be receiving requests from other replicas in the hashring before they are ready to accept them. Due to the nature of how receiver works, it can take some time until receiver's storage is ready. Depending on your roll out strategy, you might see an increased failure rate in your hashring until enough replicas are in a ready state.
+By default, upon a scale up, the controller adds all new receiver replicas into the hashring as soon as they are in a _running_ state.
+However, this means the new replicas will be receiving requests from other replicas in the hashring before they are ready to accept them.
+Due to the nature of how receiver works, it can take some time until receiver's storage is ready.
+Depending on your roll out strategy, you might see an increased failure rate in your hashring until enough replicas are in a ready state.
 
-An alternative is to use the `--allow-only-ready-replicas`, which modifies this behavior. Instead, upon a scale-up, new replicas are added only after it is confirmed they are ready. This means:
+An alternative is to use the `--allow-only-ready-replicas`, which modifies this behavior.
+Instead, upon a scale-up, new replicas are added only after it is confirmed they are ready.
+This means:
 - Old replicas keep operating with the old hashring, until all new replicas are ready. Once this is true, the hashring is updated to include all replicas in the stateful set
 - New replicas will initially come up with the old hashring configuration. This means they will serve only as a "router" and any requests that they receive will be forwarded to replicas in the old hashring. Once _all_ new receiver replicas are ready, the hashring will be updated to include both old and new replicas.

--- a/README.md
+++ b/README.md
@@ -78,3 +78,13 @@ Instead, upon a scale-up, new replicas are added only after it is confirmed they
 This means:
 - Old replicas keep operating with the old hashring, until all new replicas are ready. Once this is true, the hashring is updated to include all replicas in the stateful set
 - New replicas will initially come up with the old hashring configuration. This means they will serve only as a "router" and any requests that they receive will be forwarded to replicas in the old hashring. Once _all_ new receiver replicas are ready, the hashring will be updated to include both old and new replicas.
+
+
+## About the `--allow-dynamic-scaling` flag
+By default, the controller does not react to voluntary/involuntary distributions to receiver replicas in the StatefulSet.
+This flag allows the user to enable this behavior.
+When enabled, the controller will react to voluntary/involuntary distributions to receiver replicas in the StatefulSet.
+When a Pod is marked for termination, the controller will remove it from the hashring and the replica essentially becomes a "router" for the hashring.
+When a Pod is deleted, the controller will remove it from the hashring.
+When a Pod becomes unready, the controller will remove it from the hashring.
+This behaviour can be considered for use alongside the [Ketama hashing algorithm](https://thanos.io/tip/components/receive.md/#ketama-recommended).

--- a/jsonnet/lib/thanos-receive-controller.libsonnet
+++ b/jsonnet/lib/thanos-receive-controller.libsonnet
@@ -14,6 +14,7 @@ local defaults = {
   serviceMonitor: false,
   annotatePodsOnChange: false,
   allowOnlyReadyReplicas: false,
+  allowDynamicScaling: false,
   ports: { http: 8080 },
   clusterDomain: '',
 
@@ -166,6 +167,11 @@ function(params) {
             (
               if trc.config.allowOnlyReadyReplicas == true then [
                 '--allow-only-ready-replicas',
+              ] else []
+            ) +
+            (
+              if trc.config.allowDynamicScaling == true then [
+                '--allow-dynamic-scaling',
               ] else []
             ),
       env: [


### PR DESCRIPTION
This change allows the user, behind a flag, to provide an actual real world view of the replicas that exist in an operable state within the hashring.

A [previous comment](https://github.com/observatorium/thanos-receive-controller/pull/91#issuecomment-1240656578) warned about the consequences of adjusting the hashring during scale down events. However, this view only makes sense and works under the assumption that the disruption is temporary or unintended. We believe there are some benefits to supports this behaviour:

- Manually scaling down a StatefulSet and removing _n_ replicas
- Configuring a StatefulSet scaling with HPA
- Reducing error rate during update events

 Configuring this flag allows the operator to provide a realistic view of the hashring and from testing, we have seen that during voluntary/involuntary disruptions, without this flag, traffic quickly builds up under load to unavailable or non-existent receivers and can rapidly make the situation hard to overcome. This flag does not entirely prevent that, but we have also witnessed that during voluntary disruptions (rollouts/updates), our error rate is much lower.