### PR TITLE
Mixin: Allow specifying an instance name filter

### DIFF
--- a/jsonnet/thanos-receive-controller-mixin/config.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/config.libsonnet
@@ -18,5 +18,6 @@
     tags: ['thanos-receive-controller-mixin', 'observatorium'],
     selector: ['%s="$%s"' % [level, level] for level in std.objectFields(thanos.hierarcies)],
     aggregator: ['%s' % level for level in std.objectFields(thanos.hierarcies)],
+    instance_name_filter: '',
   },
 }

--- a/jsonnet/thanos-receive-controller-mixin/dashboards/defaults.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/dashboards/defaults.libsonnet
@@ -28,7 +28,12 @@
       ],
 
       templating+: {
-        list+: [
+        list: [
+          if variable.name == 'datasource'
+          then variable { regex: thanos.dashboard.instance_name_filter }
+          else variable
+          for variable in super.list
+        ] + [
           template.interval(
             'interval',
             '5m,10m,30m,1h,6h,12h,auto',


### PR DESCRIPTION
This commit allow specifying the instance name filter, in order to filter the datasources shown on the dashboards.

This is similar to the change made in Thanos mixin here: https://github.com/thanos-io/thanos/pull/6273