### PR TITLE
Mixin: Correctly spell `hierarchies`

### DIFF
--- a/jsonnet/thanos-receive-controller-mixin/alerts/alerts.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/alerts/alerts.libsonnet
@@ -2,11 +2,11 @@
   local thanos = self,
   receiveController+:: {
     selector: error 'must provide selector for Thanos Receive Controller alerting rules',
-    aggregator: std.join(', ', std.objectFields(thanos.hierarcies) + ['job']),
+    aggregator: std.join(', ', std.objectFields(thanos.hierarchies) + ['job']),
   },
 
   prometheusAlerts+:: {
-    local location = if std.length(std.objectFields(thanos.hierarcies)) > 0 then ' from ' + std.join('/', ['{{$labels.%s}}' % level for level in std.objectFields(thanos.hierarcies)]) else '',
+    local location = if std.length(std.objectFields(thanos.hierarchies)) > 0 then ' from ' + std.join('/', ['{{$labels.%s}}' % level for level in std.objectFields(thanos.hierarchies)]) else '',
     groups+: [
       {
         name: 'thanos-receive-controller',
@@ -69,7 +69,7 @@
               / on (%(on)s) group_left
                 thanos_receive_controller_configmap_hash{%(selector)s} != 1
               )
-            ||| % thanos.receiveController { on: std.join(', ', std.objectFields(thanos.hierarcies)) },
+            ||| % thanos.receiveController { on: std.join(', ', std.objectFields(thanos.hierarchies)) },
             'for': '5m',
             labels: {
               severity: 'critical',

--- a/jsonnet/thanos-receive-controller-mixin/config.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/config.libsonnet
@@ -1,9 +1,9 @@
 {
   local thanos = self,
-  // Hierarcies is a way to help mixin users to add high level hierarcies to their alerts and dashboards.
+  // Hierarchies is a way to help mixin users to add high level hierarchies to their alerts and dashboards.
   // The key in the key-value pair will be used as label name in the alerts and variable name in the dashboards.
   // The value in the key-value pair will be used as a query to fetch available values for the given label name.
-  hierarcies+:: {
+  hierarchies+:: {
     // For example:
     // cluster: 'find_mi_cluster_bitte',
     namespace: 'kube_pod_info',
@@ -16,8 +16,8 @@
   dashboard+:: {
     prefix: 'Thanos / ',
     tags: ['thanos-receive-controller-mixin', 'observatorium'],
-    selector: ['%s="$%s"' % [level, level] for level in std.objectFields(thanos.hierarcies)],
-    aggregator: ['%s' % level for level in std.objectFields(thanos.hierarcies)],
+    selector: ['%s="$%s"' % [level, level] for level in std.objectFields(thanos.hierarchies)],
+    aggregator: ['%s' % level for level in std.objectFields(thanos.hierarchies)],
     instance_name_filter: '',
   },
 }

--- a/jsonnet/thanos-receive-controller-mixin/dashboards/dashboards.libsonnet
+++ b/jsonnet/thanos-receive-controller-mixin/dashboards/dashboards.libsonnet
@@ -145,12 +145,12 @@ local g = (import 'grafana-builder/grafana.libsonnet');
             template.new(
               level,
               '$datasource',
-              'label_values(%s, %s)' % [thanos.hierarcies[level], level],
+              'label_values(%s, %s)' % [thanos.hierarchies[level], level],
               label=level,
               refresh=1,
               sort=2,
             )
-            for level in std.objectFields(thanos.hierarcies)
+            for level in std.objectFields(thanos.hierarchies)
           ] + [
             template.new(
               'job',


### PR DESCRIPTION
Fix typo in the mixin.

Note: this is a breaking change for anyone changing this value downstream.