### PR TITLE
manifests: Update K8s depracated serviceAccount key

### DIFF
--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -44,4 +44,4 @@ spec:
       securityContext:
         fsGroup: 65534
         runAsUser: 65534
-      serviceAccount: thanos-receive-controller
+      serviceAccountName: thanos-receive-controller

--- a/jsonnet/lib/thanos-receive-controller.libsonnet
+++ b/jsonnet/lib/thanos-receive-controller.libsonnet
@@ -202,7 +202,7 @@ function(params) {
           spec: {
             containers: [c],
             securityContext: trc.config.securityContext,
-            serviceAccount: trc.serviceAccount.metadata.name,
+            serviceAccountName: trc.serviceAccount.metadata.name,
           },
         },
       },


### PR DESCRIPTION
**What this PR does / why we need it:**
- Changes the `serviceAccount` key which is a depreciated alias for `serviceAccountName`