### PR TITLE
annotate all pods under our domain, not just those in the STS

### DIFF
--- a/main.go
+++ b/main.go
@@ -742,6 +742,7 @@ func (c *controller) saveHashring(ctx context.Context, hashring []receive.Hashri
 
 func (c *controller) annotatePods(ctx context.Context) {
 	annotationKey := fmt.Sprintf("%s/%s", c.options.labelKey, "lastControllerUpdate")
+	updateTime := fmt.Sprintf("%d", time.Now().Unix())
 
 	// Select pods that have a controllerLabel matching ours.
 	podList, err := c.klient.CoreV1().Pods(c.options.namespace).List(ctx,
@@ -761,14 +762,14 @@ func (c *controller) annotatePods(ctx context.Context) {
 			annotations = make(map[string]string)
 		}
 
-		annotations[annotationKey] = fmt.Sprintf("%d", time.Now().Unix())
+		annotations[annotationKey] = updateTime
 		podObj.SetAnnotations(annotations)
 
 		_, err := c.klient.CoreV1().Pods(pod.Namespace).Update(ctx, podObj, metav1.UpdateOptions{})
 		if err != nil {
 			level.Error(c.logger).Log("msg", "failed to update pod", "err", err)
 		}
-	} // for range podList
+	}
 }
 
 // hashAsMetricValue generates metric value from hash of data.

--- a/main.go
+++ b/main.go
@@ -77,7 +77,6 @@ type CmdConfig struct {
 }
 
 func parseFlags() CmdConfig {
-
 	var config CmdConfig
 
 	flag.StringVar(&config.KubeConfig, "kubeconfig", "", "Path to kubeconfig")

--- a/main.go
+++ b/main.go
@@ -750,24 +750,25 @@ func (c *controller) annotatePods(ctx context.Context) {
 		})
 	if err != nil {
 		level.Error(c.logger).Log("msg", "failed to list pods belonging to controller", "err", err)
-	} else {
-		for _, pod := range podList.Items {
-			podObj := pod.DeepCopy()
+		return
+	}
 
-			annotations := podObj.ObjectMeta.Annotations
-			if annotations == nil {
-				annotations = make(map[string]string)
-			}
+	for _, pod := range podList.Items {
+		podObj := pod.DeepCopy()
 
-			annotations[annotationKey] = fmt.Sprintf("%d", time.Now().Unix())
-			podObj.SetAnnotations(annotations)
+		annotations := podObj.ObjectMeta.Annotations
+		if annotations == nil {
+			annotations = make(map[string]string)
+		}
 
-			_, err := c.klient.CoreV1().Pods(pod.Namespace).Update(ctx, podObj, metav1.UpdateOptions{})
-			if err != nil {
-				level.Error(c.logger).Log("msg", "failed to update pod", "err", err)
-			}
-		} // for range podList
-	} // if err
+		annotations[annotationKey] = fmt.Sprintf("%d", time.Now().Unix())
+		podObj.SetAnnotations(annotations)
+
+		_, err := c.klient.CoreV1().Pods(pod.Namespace).Update(ctx, podObj, metav1.UpdateOptions{})
+		if err != nil {
+			level.Error(c.logger).Log("msg", "failed to update pod", "err", err)
+		}
+	} // for range podList
 }
 
 // hashAsMetricValue generates metric value from hash of data.


### PR DESCRIPTION
`annotatePods()` only affects pods which are running in RouterIngestor mode: Pods which declare a hashring file AND are also a member of that hashring. It works by iterating through every expected pod in the STS. This has a couple of problems:
1. If the size of the STS is larger than the number of running pods (failed pods) there will be failures to update those pods. This is a nuisance error.
2. If we're operating in a split setup (Router separately from Ingestor) the controller does not know to annotate the Router pods, it only annotates the discovered STS pods. This means the Routers are left to reload their CM on their fallback timeout, instead of immediately.
3. Only StatefulSets are affected, if using Routers as Deployments instead of STS, the controller will not annotate them with updates.

This change will discover **any** pods with the `config.StatefulSetLabel` value default: `controller.receive.thanos.io=thanos-receive-controller` LABEL and add a `controller.receive.thanos.io/lastControllerUpdate` annotation to each pod when the `--annotate-pods-on-change` flag is used and a new CM is generated.

It is not necessary to specify the `controller.receive.thanos.io/hashring` label when using this feature on pods which are not part of the hashring.
