### PR TITLE
Add support for Cap'n Proto endpoints in hashring config

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,10 @@ This flag allows the user to enable this behaviour.
 When enabled, the controller will generate az aware hashring configuration based on the `--pod-az-annotation-key` flag, namely the value of the annotation key will be used as the az name for each pod.
 If not specified, the statefulset name will be used as AZ field.
 Note that Thanos has be upgraded to v0.32+ to work with new hashring endpoint struct.
+
+## About the `--capnproto-port` flag
+By default, the controller only populates the HTTP/gRPC `address` field of each hashring endpoint, using the `--port` flag.
+Thanos v0.37+ supports a faster Cap'n Proto based replication protocol, which listens on a separate port (`--receive.capnproto-address`, `19391` by default).
+Setting `--capnproto-port` to a non-zero value makes the controller additionally populate the `capnproto_address` field of every endpoint, using the same DNS name as `address` but with the configured Cap'n Proto port.
+When the flag is left at its default value of `0`, the `capnproto_address` field is omitted and the behaviour is unchanged.
+

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ type CmdConfig struct {
 	ConfigMapGeneratedName string
 	FileName               string
 	Port                   int
+	CapNProtoPort          int
 	Scheme                 string
 	InternalAddr           string
 	AllowOnlyReadyReplicas bool
@@ -90,6 +91,7 @@ func parseFlags() CmdConfig {
 	flag.StringVar(&config.ConfigMapGeneratedName, "configmap-generated-name", "", "The name of the generated and populated ConfigMap")
 	flag.StringVar(&config.FileName, "file-name", "", "The name of the configuration file in the ConfigMap")
 	flag.IntVar(&config.Port, "port", defaultPort, "The port on which receive components are listening for write requests")
+	flag.IntVar(&config.CapNProtoPort, "capnproto-port", 0, "The port on which receive components are listening for Cap'n Proto replication. If set to 0, the Cap'n Proto address is not populated in the hashring configuration")
 	flag.StringVar(&config.Scheme, "scheme", "http", "The URL scheme on which receive components accept write requests")
 	flag.StringVar(&config.InternalAddr, "internal-addr", ":8080", "The address on which internal server runs")
 	flag.BoolVar(&config.AllowOnlyReadyReplicas, "allow-only-ready-replicas", false, "Populate only Ready receiver replicas in the hashring configuration")
@@ -151,6 +153,7 @@ func main() {
 			fileName:               config.FileName,
 			namespace:              config.Namespace,
 			port:                   config.Port,
+			capnprotoPort:          config.CapNProtoPort,
 			scheme:                 config.Scheme,
 			labelKey:               labelKey,
 			labelValue:             labelValue,
@@ -337,6 +340,7 @@ type options struct {
 	fileName               string
 	namespace              string
 	port                   int
+	capnprotoPort          int
 	scheme                 string
 	labelKey               string
 	labelValue             string
@@ -705,6 +709,17 @@ func (c *controller) populateEndpoint(sts *appsv1.StatefulSet, podIndex int, err
 			clusterDomain,
 			c.options.port,
 		),
+	}
+
+	if c.options.capnprotoPort != 0 {
+		endpoint.CapNProtoAddress = fmt.Sprintf("%s-%d.%s.%s.svc%s:%d",
+			sts.Name,
+			podIndex,
+			sts.Spec.ServiceName,
+			c.options.namespace,
+			clusterDomain,
+			c.options.capnprotoPort,
+		)
 	}
 
 	if c.options.useAzAwareHashRing {

--- a/main_test.go
+++ b/main_test.go
@@ -31,6 +31,7 @@ func TestController(t *testing.T) {
 		hashrings     []receive.HashringConfig
 		statefulsets  []*appsv1.StatefulSet
 		clusterDomain string
+		capnprotoPort int
 		expected      []receive.HashringConfig
 	}{
 		{
@@ -280,6 +281,44 @@ func TestController(t *testing.T) {
 				},
 			}},
 		},
+		{
+			name:          "OneHashringOneStatefulSetWithCapNProto",
+			capnprotoPort: 19391,
+			hashrings: []receive.HashringConfig{{
+				Hashring: "hashring0",
+				Tenants:  []string{"foo", "bar"},
+			}},
+			statefulsets: []*appsv1.StatefulSet{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "hashring0",
+						Labels: map[string]string{
+							"a":              "b",
+							hashringLabelKey: "hashring0",
+						},
+					},
+					Spec: appsv1.StatefulSetSpec{
+						Replicas:    intPointer(2),
+						ServiceName: "h0",
+					},
+				},
+			},
+			clusterDomain: "cluster.local",
+			expected: []receive.HashringConfig{{
+				Hashring: "hashring0",
+				Tenants:  []string{"foo", "bar"},
+				Endpoints: []receive.Endpoint{
+					{
+						Address:          "hashring0-0.h0.namespace.svc.cluster.local:10901",
+						CapNProtoAddress: "hashring0-0.h0.namespace.svc.cluster.local:19391",
+					},
+					{
+						Address:          "hashring0-1.h0.namespace.svc.cluster.local:10901",
+						CapNProtoAddress: "hashring0-1.h0.namespace.svc.cluster.local:19391",
+					},
+				},
+			}},
+		},
 	} {
 		name := tt.name
 		hashrings := tt.hashrings
@@ -297,6 +336,7 @@ func TestController(t *testing.T) {
 				configMapGeneratedName: "generated",
 				namespace:              "namespace",
 				port:                   port,
+				capnprotoPort:          tt.capnprotoPort,
 				scheme:                 "http",
 			}
 			klient := fake.NewClientset()


### PR DESCRIPTION
Add a --capnproto-port flag that, when set to a non-zero value, populates the capnproto_address field of each hashring endpoint using the same DNS name as the gRPC/HTTP address but with the configured Cap'n Proto port. Defaults to 0 (disabled) to preserve existing behavior.